### PR TITLE
Export pipeline as json

### DIFF
--- a/kedro/framework/cli/registry.py
+++ b/kedro/framework/cli/registry.py
@@ -75,7 +75,7 @@ def export_registered_pipeline(
         all_pipeline_names = pipelines.keys()
         existing_pipelines = ", ".join(sorted(all_pipeline_names))
         raise KedroCliError(
-            f"'{name}' pipeline not found. Existing pipelines: [{existing_pipelines}]"
+            f"'{name}' pipeline not found. Pipelines registered: [{existing_pipelines}]"
         )
 
     output_file.write_text(pipeline_obj.dumps())

--- a/kedro/framework/cli/registry.py
+++ b/kedro/framework/cli/registry.py
@@ -1,4 +1,6 @@
 """A collection of CLI commands for working with registered Kedro pipelines."""
+from pathlib import Path
+
 import click
 import yaml
 
@@ -48,3 +50,33 @@ def describe_registered_pipeline(
     result = {"Nodes": nodes}
 
     click.echo(yaml.dump(result))
+
+
+@command_with_verbosity(registry, "export")
+@click.argument("name", nargs=1, default="__default__")
+@click.option(
+    "-o",
+    "--output-file",
+    help="File path to export the pipeline to. Suffix must be .json",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path, resolve_path=True),
+)
+@click.pass_obj
+def export_registered_pipeline(
+    metadata: ProjectMetadata, name: str, output_file: Path, **kwargs
+) -> None:  # noqa: unused-argument, protected-access
+    """Export a registered pipeline by providing a pipeline name."""
+    if output_file.suffix != ".json":
+        raise KedroCliError(
+            f"Output file must be a .json file. Received: '{output_file}'"
+        )
+
+    pipeline_obj = pipelines.get(name)
+    if not pipeline_obj:
+        all_pipeline_names = pipelines.keys()
+        existing_pipelines = ", ".join(sorted(all_pipeline_names))
+        raise KedroCliError(
+            f"'{name}' pipeline not found. Existing pipelines: [{existing_pipelines}]"
+        )
+
+    output_file.write_text(pipeline_obj.dumps())
+    click.echo(f"Pipeline '{name}' was exported successfully to '{output_file}'.")

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -513,7 +513,7 @@ class Node:
             kwargs = inputs
         return args, kwargs
 
-    def to_json(self) -> str:
+    def dumps(self) -> str:
         """Create a JSON representation of the node."""
         func_import_path = f"{self._func.__module__}.{self._func.__qualname__}"
         return json.dumps(
@@ -537,7 +537,7 @@ class Node:
         )
 
     @classmethod
-    def from_json(cls, json_string: str) -> Node:
+    def loads(cls, json_string: str) -> Node:
         """Create a Node instance from a JSON string."""
         data = json.loads(json_string)
         func = pydoc.locate(data["func"])

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -802,11 +802,11 @@ class Pipeline:  # noqa: too-many-public-methods
 
     @classmethod
     def loads(cls, json_str: str) -> Pipeline:
-        nodes_as_str = json.loads(json_str)["nodes"]
-        return cls(nodes=[Node.loads(n_str) for n_str in nodes_as_str])
+        nodes_as_dicts = json.loads(json_str)["nodes"]
+        return cls(nodes=[Node.from_dict(n_dict) for n_dict in nodes_as_dicts])
 
     def dumps(self) -> str:
-        return json.dumps({"nodes": [n.dumps() for n in self._nodes]})
+        return json.dumps({"nodes": [n.to_dict() for n in self._nodes]})
 
 
 def _validate_duplicate_nodes(nodes_or_pipes: Iterable[Node | Pipeline]):

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -800,6 +800,18 @@ class Pipeline:  # noqa: too-many-public-methods
 
         return json.dumps(pipeline_versioned)
 
+    @classmethod
+    def from_json(cls, json_str: str) -> Pipeline:
+        nodes_as_str = json.loads(json_str)["nodes"]
+        return cls(nodes=[Node.from_json(n_str) for n_str in nodes_as_str])
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "nodes": [n.to_json() for n in self._nodes],
+            }
+        )
+
 
 def _validate_duplicate_nodes(nodes_or_pipes: Iterable[Node | Pipeline]):
     seen_nodes: set[str] = set()

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -801,16 +801,12 @@ class Pipeline:  # noqa: too-many-public-methods
         return json.dumps(pipeline_versioned)
 
     @classmethod
-    def from_json(cls, json_str: str) -> Pipeline:
+    def loads(cls, json_str: str) -> Pipeline:
         nodes_as_str = json.loads(json_str)["nodes"]
-        return cls(nodes=[Node.from_json(n_str) for n_str in nodes_as_str])
+        return cls(nodes=[Node.loads(n_str) for n_str in nodes_as_str])
 
-    def to_json(self) -> str:
-        return json.dumps(
-            {
-                "nodes": [n.to_json() for n in self._nodes],
-            }
-        )
+    def dumps(self) -> str:
+        return json.dumps({"nodes": [n.dumps() for n in self._nodes]})
 
 
 def _validate_duplicate_nodes(nodes_or_pipes: Iterable[Node | Pipeline]):

--- a/tests/pipeline/test_serialisation.py
+++ b/tests/pipeline/test_serialisation.py
@@ -39,16 +39,21 @@ def test_node_tojson() -> None:
         tags=["tag2", "tag1"],
         confirms=["b", "a"],
     )
-    assert (
-        n.dumps()
-        == '{"func": "tests.pipeline.test_serialisation.func", "inputs": "my-input", "outputs": "my-output", "name": "my-name", "namespace": "my-ns", "tags": ["tag1", "tag2"], "confirms": ["a", "b"]}'
-    )
+    assert n.to_dict() == {
+        "func": "tests.pipeline.test_serialisation.func",
+        "inputs": "my-input",
+        "outputs": "my-output",
+        "name": "my-name",
+        "namespace": "my-ns",
+        "tags": ["tag1", "tag2"],
+        "confirms": ["a", "b"],
+    }
 
 
 def test_node_roundtrip(node: Node) -> None:
     """Should end up with the very same Node after a JSON roundtrip."""
-    s = node.dumps()
-    new_node = Node.loads(s)
+    s = node.to_dict()
+    new_node = Node.from_dict(s)
 
     assert node is not new_node
     assert node == new_node
@@ -56,8 +61,8 @@ def test_node_roundtrip(node: Node) -> None:
 
 def test_node_result(node: Node) -> None:
     """The result of a node should remain the same after a JSON roundtrip."""
-    s = node.dumps()
-    new_node = Node.loads(s)
+    s = node.to_dict()
+    new_node = Node.from_dict(s)
 
     assert new_node.run({"a": 2}) == {"b": 4}
     assert new_node.run({"a": 3}) == {"b": 8}
@@ -69,7 +74,11 @@ def test_node_input_types() -> None:
     n1 = Node(func=func, inputs="random_name", outputs="b")
     n2 = Node(func=func, inputs=["random_name"], outputs="b")
     n3 = Node(func=func, inputs={"x": "random_name"}, outputs="b")
-    assert Node.loads(n1.dumps()) == Node.loads(n2.dumps()) == Node.loads(n3.dumps())
+    assert (
+        Node.from_dict(n1.to_dict())
+        == Node.from_dict(n2.to_dict())
+        == Node.from_dict(n3.to_dict())
+    )
 
 
 def test_pipe_roundtrip(pipe: Pipeline) -> None:

--- a/tests/pipeline/test_serialisation.py
+++ b/tests/pipeline/test_serialisation.py
@@ -39,23 +39,16 @@ def test_node_tojson() -> None:
         tags=["tag2", "tag1"],
         confirms=["b", "a"],
     )
-    assert n.to_json() == ", ".join(
-        [
-            '{"func": "tests.pipeline.test_serialisation.func"',
-            '"inputs": "my-input"',
-            '"outputs": "my-output"',
-            '"name": "my-name"',
-            '"namespace": "my-ns"',
-            '"tags": ["tag1", "tag2"]',
-            '"confirms": ["a", "b"]}',
-        ]
+    assert (
+        n.dumps()
+        == '{"func": "tests.pipeline.test_serialisation.func", "inputs": "my-input", "outputs": "my-output", "name": "my-name", "namespace": "my-ns", "tags": ["tag1", "tag2"], "confirms": ["a", "b"]}'
     )
 
 
 def test_node_roundtrip(node: Node) -> None:
     """Should end up with the very same Node after a JSON roundtrip."""
-    s = node.to_json()
-    new_node = Node.from_json(s)
+    s = node.dumps()
+    new_node = Node.loads(s)
 
     assert node is not new_node
     assert node == new_node
@@ -63,8 +56,8 @@ def test_node_roundtrip(node: Node) -> None:
 
 def test_node_result(node: Node) -> None:
     """The result of a node should remain the same after a JSON roundtrip."""
-    s = node.to_json()
-    new_node = Node.from_json(s)
+    s = node.dumps()
+    new_node = Node.loads(s)
 
     assert new_node.run({"a": 2}) == {"b": 4}
     assert new_node.run({"a": 3}) == {"b": 8}
@@ -76,17 +69,13 @@ def test_node_input_types() -> None:
     n1 = Node(func=func, inputs="random_name", outputs="b")
     n2 = Node(func=func, inputs=["random_name"], outputs="b")
     n3 = Node(func=func, inputs={"x": "random_name"}, outputs="b")
-    assert (
-        Node.from_json(n1.to_json())
-        == Node.from_json(n2.to_json())
-        == Node.from_json(n3.to_json())
-    )
+    assert Node.loads(n1.dumps()) == Node.loads(n2.dumps()) == Node.loads(n3.dumps())
 
 
 def test_pipe_roundtrip(pipe: Pipeline) -> None:
     """Should end up with the very same Pipeline after a JSON roundtrip."""
-    s = pipe.to_json()
-    new_pipe = Pipeline.from_json(s)
+    s = pipe.dumps()
+    new_pipe = Pipeline.loads(s)
 
     assert pipe is not new_pipe
     assert sorted(new_pipe.nodes) == sorted(pipe.nodes)
@@ -94,8 +83,8 @@ def test_pipe_roundtrip(pipe: Pipeline) -> None:
 
 def test_pipe_result(pipe: Pipeline) -> None:
     """The result of a pipeline should remain the same after a JSON roundtrip."""
-    s = pipe.to_json()
-    new_pipe = Pipeline.from_json(s)
+    s = pipe.dumps()
+    new_pipe = Pipeline.loads(s)
 
     cat = DataCatalog(feed_dict={"a": 2, "e": 3})
     exp = {

--- a/tests/pipeline/test_serialisation.py
+++ b/tests/pipeline/test_serialisation.py
@@ -1,0 +1,105 @@
+import pytest
+
+from kedro.io import DataCatalog
+from kedro.pipeline import Pipeline
+from kedro.pipeline.node import Node
+from kedro.runner import SequentialRunner
+
+
+def func(x: float) -> float:
+    """Dummy func to use in tests."""
+    return 2**x
+
+
+@pytest.fixture(name="node")
+def fixture_node() -> Node:
+    """Dummy node to use in tests."""
+    return Node(func=func, inputs="a", outputs="b")
+
+
+@pytest.fixture(name="pipe")
+def fixture_pipe() -> Pipeline:
+    """Dummy pipeline to use in tests."""
+    n1 = Node(func=func, inputs="a", outputs="b")
+    n2 = Node(func=func, inputs="b", outputs="c")
+    n3 = Node(func=func, inputs="c", outputs="d")
+    n4 = Node(func=func, inputs="e", outputs="f")
+
+    return Pipeline([n1, n2, n3, n4])
+
+
+def test_node_tojson() -> None:
+    """Generated JSON string is correct."""
+    n = Node(
+        func=func,
+        inputs="my-input",
+        outputs="my-output",
+        namespace="my-ns",
+        name="my-name",
+        tags=["tag2", "tag1"],
+        confirms=["b", "a"],
+    )
+    assert n.to_json() == ", ".join(
+        [
+            '{"func": "tests.pipeline.test_serialisation.func"',
+            '"inputs": "my-input"',
+            '"outputs": "my-output"',
+            '"name": "my-name"',
+            '"namespace": "my-ns"',
+            '"tags": ["tag1", "tag2"]',
+            '"confirms": ["a", "b"]}',
+        ]
+    )
+
+
+def test_node_roundtrip(node: Node) -> None:
+    """Should end up with the very same Node after a JSON roundtrip."""
+    s = node.to_json()
+    new_node = Node.from_json(s)
+
+    assert node is not new_node
+    assert node == new_node
+
+
+def test_node_result(node: Node) -> None:
+    """The result of a node should remain the same after a JSON roundtrip."""
+    s = node.to_json()
+    new_node = Node.from_json(s)
+
+    assert new_node.run({"a": 2}) == {"b": 4}
+    assert new_node.run({"a": 3}) == {"b": 8}
+
+
+@pytest.mark.xfail(reason="We keep the initial form of the inputs")
+def test_node_input_types() -> None:
+    """Should JSON representation of Nodes be the same if their input/output forms are different?"""
+    n1 = Node(func=func, inputs="random_name", outputs="b")
+    n2 = Node(func=func, inputs=["random_name"], outputs="b")
+    n3 = Node(func=func, inputs={"x": "random_name"}, outputs="b")
+    assert (
+        Node.from_json(n1.to_json())
+        == Node.from_json(n2.to_json())
+        == Node.from_json(n3.to_json())
+    )
+
+
+def test_pipe_roundtrip(pipe: Pipeline) -> None:
+    """Should end up with the very same Pipeline after a JSON roundtrip."""
+    s = pipe.to_json()
+    new_pipe = Pipeline.from_json(s)
+
+    assert pipe is not new_pipe
+    assert sorted(new_pipe.nodes) == sorted(pipe.nodes)
+
+
+def test_pipe_result(pipe: Pipeline) -> None:
+    """The result of a pipeline should remain the same after a JSON roundtrip."""
+    s = pipe.to_json()
+    new_pipe = Pipeline.from_json(s)
+
+    cat = DataCatalog(feed_dict={"a": 2, "e": 3})
+    exp = {
+        "d": 65536,  # 2 ** (2 ** (2 ** 2))
+        "f": 8,  # 2 ** 3
+    }
+    assert SequentialRunner().run(pipeline=new_pipe, catalog=cat) == exp


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Makes it possible to serialise pipeline objects in a way that the serialised file can be used by plugins as a proxy for the real pipeline object, i.e. get the structure of the execution graph and get attributes of nodes without needing to import the kedro project or any dependencies of it.

## Development notes
<!-- What have you changed, and how has this been tested? -->
PR adds:
- `to_dict()/from_dict()` methods to `Node`, which do the two-way conversion of Node to a dictionary storing the attributes of the node
- `dumps()/loads()` methods to `Pipeline`, which create a JSON string representation of the Pipeline. The main difference between `dumps()` and the existing `Pipeline.to_json()` is that the former includes the full import paths for the node function too.
- tests for the added methods

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
